### PR TITLE
Adds instance creation with multipass to macOS script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@ run command `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.Servi
 ```
 
 ## MacOS Setup
-Install homebrew and multipass
+This script:
+- Installs homebrew
+- Installs multipass using homebrew
+- Launches an instance named `relativepath` using multipass
+- Outputs distro information using `multipass exec`
+
 ```
 Set script as executable
 $ chmod +x macos_packages.sh

--- a/macos_packages.sh
+++ b/macos_packages.sh
@@ -6,3 +6,10 @@ NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Ho
 
 echo "installing multipass"
 brew install --cask multipass
+
+echo "launching relativepath instance with multipass"
+multipass launch --name relativepath
+
+echo "show distro information using multipass exec"
+multipass exec relativepath -- lsb_release -a
+


### PR DESCRIPTION
This PR:
- Update readme to include multipass launch and exec distro info
- Creates an instance named 'relativepath' with multipass in macOS script
- Output distro information from our instance